### PR TITLE
iOS image height downsizing fix

### DIFF
--- a/css/demandcalc.css
+++ b/css/demandcalc.css
@@ -15,7 +15,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  min-height: -webkit-fill-available;
 }
 
 .navbar, .content, .footer {
@@ -308,7 +307,6 @@ h2 {
 
   .content-image {
     min-height: 100vh;
-    min-height: -webkit-fill-available;
   }
 
   .credits p {
@@ -345,5 +343,17 @@ h2 {
   h2 {
     margin-bottom: 20px;
     font-size: 1.5rem;
+  }
+
+  @supports (height: 100dvh) {
+    .wrapper {
+      min-height: 100dvh;
+    }
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .wrapper {
+      min-height: -webkit-fill-available;
+    }
   }
 }

--- a/css/pointscalc.css
+++ b/css/pointscalc.css
@@ -15,7 +15,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  min-height: -webkit-fill-available;
 }
 
 .navbar, .content, .footer {
@@ -300,7 +299,6 @@ h2 {
 
   .content-image {
     min-height: 100vh;
-    min-height: -webkit-fill-available;
   }
 
   .credits p {
@@ -343,5 +341,17 @@ h2 {
     width: 100%;
     font-size: 14px;
     color: #999999;
+  }
+
+  @supports (height: 100dvh) {
+    .wrapper {
+      min-height: 100dvh;
+    }
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .wrapper {
+      min-height: -webkit-fill-available;
+    }
   }
 }

--- a/css/resources.css
+++ b/css/resources.css
@@ -15,7 +15,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  min-height: -webkit-fill-available;
 }
 
 .navbar, .content, .footer {
@@ -276,7 +275,6 @@ a {
 
   .content-image {
     min-height: 100vh;
-    min-height: -webkit-fill-available;
   }
 
   .credits p {
@@ -312,6 +310,15 @@ a {
     margin-bottom: 10px;
   }
 
+  @supports (height: 100dvh) {
+    .wrapper {
+      min-height: 100dvh;
+    }
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .wrapper {
+      min-height: -webkit-fill-available;
+    }
+  }
 }
-
-

--- a/css/style.css
+++ b/css/style.css
@@ -15,7 +15,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  min-height: -webkit-fill-available;
 }
 
 .navbar, .content, .footer {
@@ -248,7 +247,6 @@ body {
 
   .content-image {
     min-height: 100vh;
-    min-height: -webkit-fill-available;
   }
 
   .credits p {
@@ -259,5 +257,16 @@ body {
     font-size: 0.6rem;
     padding-top: 12px;
   }
-}
 
+  @supports (height: 100dvh) {
+    .wrapper {
+      min-height: 100dvh;
+    }
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .wrapper {
+      min-height: -webkit-fill-available;
+    }
+  }
+}


### PR DESCRIPTION
Fix for the issue where the background image downsizes on webkit-based browsers (iOS browsers, mostly) due to the unsupported `vh`/`dvh` size properties without the `-webkit-fill-available` flag, which must be applied based on support rather than universally.