### PR TITLE
points calc breakdown by system

### DIFF
--- a/css/pointscalc.css
+++ b/css/pointscalc.css
@@ -159,7 +159,7 @@ body {
   transform: translate(-50%, -50%);
   text-align: center;
   padding: 20px;
-  font-size: 1.25rem;
+  font-size: 1rem;
   background: linear-gradient(135deg, rgba(128, 128, 128, 0.4), rgba(0, 0, 0, 0.7));
   border-radius: 10px;
   color: white;
@@ -214,6 +214,132 @@ h2 {
     color: #999999;
 }
 
+.systems-container {
+  margin-bottom: 20px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.systems-header {
+  background: rgba(255, 203, 91, 0.8);
+  padding: 12px 20px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background 0.3s;
+}
+
+.systems-header:hover {
+  background: rgba(255, 152, 0, 0.9);
+}
+
+.systems-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.dropdown-arrow {
+  font-size: 1rem;
+  transition: transform 0.3s;
+}
+
+.systems-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease-out;
+  padding: 0 20px;
+}
+
+.systems-content.show {
+  max-height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 20px;
+  transition: max-height 0.3s ease-in;
+}
+
+.systems-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.systems-content::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+}
+
+.systems-content::-webkit-scrollbar-thumb {
+  background: rgba(255, 152, 0, 0.6);
+  border-radius: 4px;
+}
+
+.systems-content::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 152, 0, 0.8);
+}
+
+.system-group {
+  margin-bottom: 15px;
+  padding: 15px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  border-left: 3px solid #ff9800;
+}
+
+.system-group h4 {
+  margin: 0 0 10px 0;
+  color: #ff9800;
+  font-size: 1rem;
+}
+
+.subsystems {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.subsystems label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 5px;
+  border-radius: 4px;
+  transition: background 0.2s;
+  font-size: 0.9rem;
+}
+
+.subsystems label:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.subsystem-toggle {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+}
+
+.system-rate {
+  text-align: right;
+  font-size: 0.95rem;
+  color: #4CAF50;
+  font-weight: bold;
+  margin-top: 8px;
+}
+
+.total-rate {
+  text-align: center;
+  padding: 15px;
+  background: rgba(76, 175, 80, 0.2);
+  border-radius: 6px;
+  font-size: 1.1rem;
+  margin-top: 10px;
+}
+
+.total-rate strong {
+  color: #4CAF50;
+}
 
 .footer {
   background: linear-gradient(30deg, #c14141, #62bf66);

--- a/css/pointscalc.css
+++ b/css/pointscalc.css
@@ -222,7 +222,7 @@ h2 {
 }
 
 .systems-header {
-  background: rgba(255, 203, 91, 0.8);
+  background: rgba(255, 152, 0, 0.9);
   padding: 12px 20px;
   cursor: pointer;
   display: flex;

--- a/css/pointscalc.css
+++ b/css/pointscalc.css
@@ -156,10 +156,10 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -53%);
   text-align: center;
   padding: 20px;
-  font-size: 1rem;
+  font-size: 0.9rem;
   background: linear-gradient(135deg, rgba(128, 128, 128, 0.4), rgba(0, 0, 0, 0.7));
   border-radius: 10px;
   color: white;
@@ -215,7 +215,7 @@ h2 {
 }
 
 .systems-container {
-  margin-bottom: 20px;
+  margin-bottom: 15px;
   background: rgba(0, 0, 0, 0.3);
   border-radius: 8px;
   overflow: hidden;
@@ -237,7 +237,7 @@ h2 {
 
 .systems-header h3 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .dropdown-arrow {

--- a/js/pointscalc.js
+++ b/js/pointscalc.js
@@ -1,4 +1,3 @@
-
 class Rank {
     constructor(name, points) {
         this.name = name;
@@ -7,7 +6,7 @@ class Rank {
 }
 
 const ranks = [
-  new Rank("Plant Manager", 10000000),
+    new Rank("Plant Manager", 10000000),
     new Rank("Chief Inspector", 5000000),
     new Rank("Senior Inspector", 2000000),
     new Rank("Inspector", 1000000),
@@ -23,6 +22,60 @@ const ranks = [
     new Rank("Visitor", 0)
 ];
 
+const subsystemStates = {
+    // measured in autos on
+    u1: {},
+    u2: {},
+    tcr: {},
+    fwp: false,
+
+    // meets (by unit)
+    demand: {}
+};
+function calculateU1Rate() {
+    const maxPPS = 1;
+
+    const autosActiveCount = Object.values(subsystemStates.u1).filter(v => v).length;
+    const basePoints = maxPPS / (autosActiveCount + 1);
+
+    return subsystemStates.demand[1] ? basePoints : 0;
+}
+function calculateU2Rate() {
+    const maxPPS = 1;
+
+    const autosActiveCount = Object.values(subsystemStates.u2).filter(v => v).length;
+    const basePoints = maxPPS / (autosActiveCount + 1);
+
+    return subsystemStates.demand[2] ? basePoints : 0;
+}
+function calculateTCRRate() {
+    const maxPPS = 1/3;
+
+    const values = Object.values(subsystemStates.tcr);
+    const autosActiveCount = values.filter(v => v).length;
+    const basePoints = maxPPS * (1 - autosActiveCount / values.length)
+
+    return subsystemStates.demand[2] ? basePoints : 0;
+}
+function calculateFWPRate() {
+    const maxPPS = 0.1;
+    return (!subsystemStates.fwp && subsystemStates.demand[2]) ? maxPPS : 0;
+}
+function calculateDemandRate() {
+    const maxPPS = 0.4;
+
+    const values = Object.values(subsystemStates.demand);
+    const unitsMet = values.filter(v => v).length;
+    return maxPPS * (unitsMet / values.length);
+}
+function calculateTotalRate() {
+    const u1Rate = calculateU1Rate();
+    const u2Rate = calculateU2Rate();
+    const tcrRate = calculateTCRRate();
+    const fwpRate = calculateFWPRate();
+    const demandRate = calculateDemandRate();
+    return (u1Rate + u2Rate + tcrRate + fwpRate + demandRate)  || 0;
+}
 
 function calculateRank(totalPoints) {
     let currentRank = ranks[ranks.length - 1];
@@ -46,16 +99,19 @@ function calculateRank(totalPoints) {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-    const unit1Input = document.getElementById('unit1');
-    const unit2Input = document.getElementById('unit2');
-    const totalInput = document.getElementById('total');
-    const currentRankElement = document.getElementById('current-rank');
-    const nextRankElement = document.getElementById('next-rank');
-    const pointsNeededInput = document.getElementById('points-needed');
-    const minutesUntil = document.getElementById('time-until');
+  const unit1Input = document.getElementById('unit1');
+  const unit2Input = document.getElementById('unit2');
+  const totalInput = document.getElementById('total');
+  const currentRankElement = document.getElementById('current-rank');
+  const nextRankElement = document.getElementById('next-rank');
+  const pointsNeededInput = document.getElementById('points-needed');
+  const minutesUntil = document.getElementById('time-until');
   const navbarToggle = document.querySelector('.navbar-toggle');
   const navbarlinks = document.querySelector('.navbar-links');
   const navbar = document.querySelector('.navbar');
+
+  const systemsToggle = document.getElementById('systems-toggle');
+  const systemsContent = document.getElementById('systems-content');
 
   if (navbarToggle && navbar && navbarlinks) {
     navbarToggle.addEventListener('click', function () {
@@ -66,25 +122,78 @@ document.addEventListener('DOMContentLoaded', function () {
     console.error("Navbar toggle or navbar elements not found!");
   }
 
-    function updateRanks() {
-        const unit1 = parseFloat(unit1Input.value) || 0;
-        const unit2 = parseFloat(unit2Input.value) || 0;
-        const totalPoints = unit1 + unit2;
-        totalInput.value = totalPoints;
+  if (systemsToggle && systemsContent) {
+    systemsToggle.addEventListener('click', function() {
+      systemsContent.classList.toggle('show');
+      const arrow = systemsToggle.querySelector('.dropdown-arrow');
+      arrow.textContent = systemsContent.classList.contains('show') ? '▲' : '▼';
+    });
+  }
 
-        const { currentRank, nextRank, remainingPoints } = calculateRank(totalPoints);
-        console.log(totalPoints)
-
-
-      currentRankElement.textContent = currentRank.name;
-        nextRankElement.textContent = nextRank ? nextRank.name : 'Highest Rank achieved';
-        pointsNeededInput.value = remainingPoints;
-
-      minutesUntil.value = Math.floor((remainingPoints / 2.9) / 60);
+  const allToggles = document.querySelectorAll('.subsystem-toggle');
+  allToggles.forEach(toggle => {
+    const system = toggle.dataset.system;
+    if (system === "fwp") { // boolean systems
+      subsystemStates[system] = toggle.checked;
+    } else { // array systems
+      const subsystem = toggle.dataset.subsystem;
+      subsystemStates[system][subsystem] = toggle.checked;
     }
+  });
 
-    unit1Input.addEventListener('input', updateRanks);
-    unit2Input.addEventListener('input', updateRanks);
+  allToggles.forEach(toggle => {
+    toggle.addEventListener('change', function() {
+      const system = toggle.dataset.system;
+      if (system === "fwp") { // boolean systems
+        subsystemStates[system] = this.checked;
+      } else { // array systems
+        const subsystem = this.dataset.subsystem;
+        subsystemStates[system][subsystem] = this.checked;
+      }
+      updateRates();
+      updateRanks();
+    });
+  });
 
-    updateRanks();
+  function updateRates() {
+    const u1Rate = calculateU1Rate();
+    const u2Rate = calculateU2Rate();
+    const tcrRate = calculateTCRRate();
+    const fwpRate = calculateFWPRate();
+    const demandRate = calculateDemandRate();
+    const totalRate = u1Rate + u2Rate + tcrRate + fwpRate + demandRate;
+
+    document.getElementById('u1-rate').textContent = u1Rate.toFixed(2);
+    document.getElementById('u2-rate').textContent = u2Rate.toFixed(2);
+    document.getElementById('tcr-rate').textContent = tcrRate.toFixed(2);
+    document.getElementById('fwp-rate').textContent = fwpRate.toFixed(2);
+    document.getElementById('demand-rate').textContent = demandRate.toFixed(2);
+    document.getElementById('total-rate').textContent = totalRate.toFixed(2);
+
+    return totalRate || 0;
+  }
+
+  function updateRanks() {
+    const unit1 = parseFloat(unit1Input.value) || 0;
+    const unit2 = parseFloat(unit2Input.value) || 0;
+    const totalPoints = unit1 + unit2;
+    totalInput.value = totalPoints;
+
+    const { currentRank, nextRank, remainingPoints } = calculateRank(totalPoints);
+
+    currentRankElement.textContent = currentRank.name;
+    nextRankElement.textContent = nextRank ? nextRank.name : 'Highest Rank achieved';
+    pointsNeededInput.value = remainingPoints;
+
+    const activeRate = updateRates();
+
+    if (activeRate > 0) { minutesUntil.value = Math.floor(remainingPoints / activeRate / 60);
+    } else { minutesUntil.value = 'inf'; }
+  }
+
+  unit1Input.addEventListener('input', updateRanks);
+  unit2Input.addEventListener('input', updateRanks);
+
+  updateRates();
+  updateRanks();
 });

--- a/js/pointscalc.js
+++ b/js/pointscalc.js
@@ -170,6 +170,16 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('demand-rate').textContent = demandRate.toFixed(2);
     document.getElementById('total-rate').textContent = totalRate.toFixed(2);
 
+    const u1Warning = document.getElementById('u1-demand-warning');
+    const u2Warning = document.getElementById('u2-demand-warning');
+    const tcrWarning = document.getElementById('tcr-demand-warning');
+    const fwpWarning = document.getElementById('fwp-demand-warning');
+
+    if (u1Warning) { u1Warning.style.display = !subsystemStates.demand[1] ? 'inline' : 'none'; }
+    if (u2Warning) { u2Warning.style.display = !subsystemStates.demand[2] ? 'inline' : 'none'; }
+    if (tcrWarning) { tcrWarning.style.display = !subsystemStates.demand[2] ? 'inline' : 'none'; }
+    if (fwpWarning) { fwpWarning.style.display = !subsystemStates.demand[2] ? 'inline' : 'none'; }
+
     return totalRate || 0;
   }
 

--- a/tools/pointscalc.html
+++ b/tools/pointscalc.html
@@ -64,7 +64,8 @@
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="4" unchecked> Balancer Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="5" unchecked> Condenser Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="6" unchecked> Deaerator Auto</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="7" unchecked> Deaerator Configured</label>
+
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1_da_config" data-subsystem="1" checked> Deaerator Configured</label>
                         </div>
                         <div class="system-rate">Current Rate: <span id="u1-rate">1.00</span> pts/s</div>
                     </div>
@@ -79,7 +80,8 @@
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="5" unchecked> Condenser Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="6" unchecked> Deaerator Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="7" unchecked> EDG Auto</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="8" unchecked> Deaerator Configured</label>
+
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_da_config" data-subsystem="1" checked> Deaerator Configured</label>
                         </div>
                         <div class="system-rate">Current Rate: <span id="u2-rate">1.00</span> pts/s</div>
                     </div>
@@ -104,8 +106,10 @@
                     <div class="system-group">
                         <h4>Plant Demand (Max: 0.4 pts/s)</h4>
                         <div class="subsystems">
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="demand" data-subsystem="1" checked> U1 Demand Met</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="demand" data-subsystem="2" checked> U2 Demand Met</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="demandU" data-subsystem="1" checked> U1 Demand Met</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="demandU" data-subsystem="2" checked> U2 Demand Met</label>
+
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="demandP" data-subsystem="1" checked> Whole Plant Demand Met</label>
                         </div>
                         <div class="system-rate">Current Rate: <span id="demand-rate">0.40</span> pts/s</div>
                     </div>

--- a/tools/pointscalc.html
+++ b/tools/pointscalc.html
@@ -51,12 +51,12 @@
 
             <div class="systems-container">
                 <div class="systems-header" id="systems-toggle">
-                    <h3>Point Rate Systems</h3>
+                    <h3>Breakdown by Systems</h3>
                     <span class="dropdown-arrow">▼</span>
                 </div>
                 <div class="systems-content" id="systems-content">
                     <div class="system-group">
-                        <h4>U1 (Max: 1.0 pts/s)</h4>
+                        <h4>U1 (Max: 1.0 pts/s) <span id="u1-demand-warning" style="color: red; font-size: 0.9em; display: none;">- Unit 1 demand isn't met</span></h4>
                         <div class="subsystems">
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="1" unchecked> Turbine Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="2" unchecked> Reactor Auto</label>
@@ -70,7 +70,7 @@
                     </div>
 
                     <div class="system-group">
-                        <h4>U2 (Max: 1.0 pts/s)</h4>
+                        <h4>U2 (Max: 1.0 pts/s) <span id="u2-demand-warning" style="color: red; font-size: 0.9em; display: none;">- Unit 2 demand isn't met</span></h4>
                         <div class="subsystems">
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="1" unchecked> Turbine Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="2" unchecked> Reactor Auto</label>
@@ -85,7 +85,7 @@
                     </div>
 
                     <div class="system-group">
-                        <h4>TCR (Max: 0.33 pts/s)</h4>
+                        <h4>TCR (Max: 0.33 pts/s) <span id="tcr-demand-warning" style="color: red; font-size: 0.9em; display: none;">- Unit 2 demand isn't met</span></h4>
                         <div class="subsystems">
                             <label><input type="checkbox" class="subsystem-toggle" data-system="tcr" data-subsystem="1" unchecked> Steam Sealing Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="tcr" data-subsystem="2" unchecked> Oil Temp Auto</label>
@@ -94,7 +94,7 @@
                     </div>
 
                     <div class="system-group">
-                        <h4>U2 FWP (Max: 0.1 pts/s)</h4>
+                        <h4>U2 FWP (Max: 0.1 pts/s) <span id="fwp-demand-warning" style="color: red; font-size: 0.9em; display: none;">- Unit 2 demand isn't met</span></h4>
                         <div class="subsystems">
                             <label><input type="checkbox" class="subsystem-toggle" data-system="fwp" unchecked> Auto</label>
                         </div>
@@ -129,22 +129,10 @@
             </div>
 
             <div class="output">
-                <div class="input-group">
-                    <label for="time-until">Minutes until next rank</label>
-                    <input type="number" id="time-until" value="5" readonly>
-                </div>
-
-                <div class="input-group">
-                    <label for="points-needed">Points until next rank</label>
-                    <input type="number" id="points-needed" value="1000" readonly>
-                </div>
-            </div>
-
-            <div class="output">
                 <div class="rank-info">
-                    <p>Your current rank is: <span id="current-rank">Visitor</span></p>
-                    <p>Your next rank will be: <span id="next-rank">Trainee</span></p>
-                    <h6><i>Note: Points granted from Inspections aren't considered in this calculator.</i></h6>
+                    <p><b>Your current rank is: <i><span id="current-rank">Visitor</span></i></b></p>
+                    <p><b>Your next rank will be: <i><span id="next-rank">Trainee</span></i></b></p>
+                    <small><i>Note: Points granted from Inspections aren't considered in this calculator.</i></small>
                 </div>
             </div>
         </div>

--- a/tools/pointscalc.html
+++ b/tools/pointscalc.html
@@ -51,7 +51,7 @@
 
             <div class="systems-container">
                 <div class="systems-header" id="systems-toggle">
-                    <h3>Breakdown by Systems</h3>
+                    <h3>Breakdown by System</h3>
                     <span class="dropdown-arrow">▼</span>
                 </div>
                 <div class="systems-content" id="systems-content">

--- a/tools/pointscalc.html
+++ b/tools/pointscalc.html
@@ -49,6 +49,85 @@
                 </div>
             </div>
 
+            <div class="systems-container">
+                <div class="systems-header" id="systems-toggle">
+                    <h3>Point Rate Systems</h3>
+                    <span class="dropdown-arrow">▼</span>
+                </div>
+                <div class="systems-content" id="systems-content">
+                    <div class="system-group">
+                        <h4>U1 (Max: 1.0 pts/s)</h4>
+                        <div class="subsystems">
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="1" unchecked> Turbine Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="2" unchecked> Reactor Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="3" unchecked> MCC Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="4" unchecked> Balancer Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="5" unchecked> Condenser Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="6" unchecked> Deaerator Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u1" data-subsystem="7" unchecked> Deaerator Configured</label>
+                        </div>
+                        <div class="system-rate">Current Rate: <span id="u1-rate">1.00</span> pts/s</div>
+                    </div>
+
+                    <div class="system-group">
+                        <h4>U2 (Max: 1.0 pts/s)</h4>
+                        <div class="subsystems">
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="1" unchecked> Turbine Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="2" unchecked> Reactor Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="3" unchecked> MCC Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="4" unchecked> Balancer Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="5" unchecked> Condenser Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="6" unchecked> Deaerator Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="7" unchecked> EDG Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="8" unchecked> Deaerator Configured</label>
+                        </div>
+                        <div class="system-rate">Current Rate: <span id="u2-rate">1.00</span> pts/s</div>
+                    </div>
+
+                    <div class="system-group">
+                        <h4>TCR (Max: 0.33 pts/s)</h4>
+                        <div class="subsystems">
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="tcr" data-subsystem="1" unchecked> Steam Sealing Auto</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="tcr" data-subsystem="2" unchecked> Oil Temp Auto</label>
+                        </div>
+                        <div class="system-rate">Current Rate: <span id="tcr-rate">0.33</span> pts/s</div>
+                    </div>
+
+                    <div class="system-group">
+                        <h4>U2 FWP (Max: 0.1 pts/s)</h4>
+                        <div class="subsystems">
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="fwp" unchecked> Auto</label>
+                        </div>
+                        <div class="system-rate">Current Rate: <span id="fwp-rate">0.1</span> pts/s</div>
+                    </div>
+
+                    <div class="system-group">
+                        <h4>Plant Demand (Max: 0.4 pts/s)</h4>
+                        <div class="subsystems">
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="demand" data-subsystem="1" checked> U1 Demand Met</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="demand" data-subsystem="2" checked> U2 Demand Met</label>
+                        </div>
+                        <div class="system-rate">Current Rate: <span id="demand-rate">0.40</span> pts/s</div>
+                    </div>
+
+                    <div class="total-rate">
+                        <strong>Total Rate: <span id="total-rate">2.90</span> pts/s</strong>
+                    </div>
+                </div>
+            </div>
+
+            <div class="output">
+                <div class="input-group">
+                    <label for="time-until">Minutes until next rank</label>
+                    <input type="text" id="time-until" value="5" readonly>
+                </div>
+
+                <div class="input-group">
+                    <label for="points-needed">Points until next rank</label>
+                    <input type="number" id="points-needed" value="1000" readonly>
+                </div>
+            </div>
+
             <div class="output">
                 <div class="input-group">
                     <label for="time-until">Minutes until next rank</label>
@@ -65,8 +144,7 @@
                 <div class="rank-info">
                     <p>Your current rank is: <span id="current-rank">Visitor</span></p>
                     <p>Your next rank will be: <span id="next-rank">Trainee</span></p>
-                    <p class="minute-info">Minutes until next rank is calculated as if both Units are fully manual and Plant Demand is
-                        met!</p>
+                    <h6><i>Note: Points granted from Inspections aren't considered in this calculator.</i></h6>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Points rate of gain breakdown by system.

**Relevant note: I have removed the points earned through Inspections** from the total point calculation since it's not a fixed gain, and therefore, any average for pts/s is unreliable; the maximum amount of pts/s from Inspections are 0.555..., however,  that's assuming Inspections are constantly and precisely being done just exactly after the 30 minute cooldown, which is not accurate.
Hence I decided to not include points from Inspections in the calculation.
_If you disagree with that, we may discuss it in this PR's discussion, but the constant rate it had of 1/6 (0.1666) pts/s doesn't make much sense to be among fixed calculations (not to mention, it's unclear where the set constant rate came from, since it's outright wrong in the most optimal case of 0.555), IMO._

Considering the aforementioned, the maximum pts/s achievable with both units meeting demand and no autos on is 2.83 pts/s.

Changes by commit:
- d65f9311e45b1eac76760d492d470068912180a5
  - Main commit: Point breakdown by system; Added a scrolling dropdown with toggles for each system's subsystem:
    - U1: Turbine Auto, Reactor Auto, MCC Auto, Balancer Auto, Condenser Auto, Deaerator Auto, Deaerator Configured
    - U2: Turbine Auto, Reactor Auto, MCC Auto, Balancer Auto, Condenser Auto, Deaerator Auto, EDG Auto, Deaerator Configured.
      - TCR: Steam Sealing Auto, Oil Temp Auto.
      - FWP: Auto.
    - Plant Demand: U1 Demand Met, U2 Demand Met.
  - Includes points given per system based on subsystem selection and total point rate all the way down.
  - Default is most optimal case (both units meeting demand, all autos off).
  - _It doesn't account the Inspections' calculation._
- 7ab6068e1fb6007a9b57d62945e8d329869e3a60
  - QoL to avoid confusion: Added a red warning to the system's header if its respective unit demand toggle is set to false; since that unit isn't meeting demand, its points default to 0.
- ab9053de098eba3374dc0c099e4369921204a619
  - Adds compatibility for visualization/interaction in mobile devices, since some stuff would be cropped out of the screen otherwise.
- a97ae6073d89e0833a05055781680cd82a720d71
  - Fixed up some bugs (brought up by bonnyyyy):
    - Plant demand being met is just the same across 2 units, not separated across 2 units (you either get 0.4 pps split on both units, or you dont get anything), you can do U1 Network Demand: -51 (-49) and U2 Network Demand: 2 (-49) and still get 0.4pps, even if U1 is out of unit demand.
    - In tcr, you get 0 pps if you have any autos turned on.
    - Both units' "DA Configured" toggle decreases points for some reason, instead increasing as intended.