### PR TITLE
EDG Calculation Fix + U2 Abnormal Config Addition

### DIFF
--- a/tools/pointscalc.html
+++ b/tools/pointscalc.html
@@ -80,8 +80,6 @@
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="5" unchecked> Condenser Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="6" unchecked> Deaerator Auto</label>
                             <label><input type="checkbox" class="subsystem-toggle" data-system="u2" data-subsystem="7" unchecked> EDG Auto</label>
-
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_da_config" data-subsystem="1" checked> Deaerator Configured</label>
                         </div>
                         <div class="system-rate">Current Rate: <span id="u2-rate">1.00</span> pts/s</div>
                     </div>
@@ -113,7 +111,18 @@
                         </div>
                         <div class="system-rate">Current Rate: <span id="demand-rate">0.40</span> pts/s</div>
                     </div>
-
+                    <div class="system-group">
+                        <h4>U2 Abnormal Configuration</h4>
+                        <div class="subsystems">
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="1" checked>Deaerator Not Configured</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="2" checked>Turbine Bypass Used</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="3" checked>Polisher Bypass Used</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="4" checked>MCC Water Levels < -3m </label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="5" checked>Turbine Aux Pump Used</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="6" checked>Feedwater Pump Temperature Low</label>
+                        </div>
+                        <div class="system-rate">Rate Decrease: <span id="abnormal-rate">0.00</span> pts/s</div>
+                    </div>
                     <div class="total-rate">
                         <strong>Total Rate: <span id="total-rate">2.90</span> pts/s</strong>
                     </div>

--- a/tools/pointscalc.html
+++ b/tools/pointscalc.html
@@ -114,12 +114,12 @@
                     <div class="system-group">
                         <h4>U2 Abnormal Configuration</h4>
                         <div class="subsystems">
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="1" checked>Deaerator Not Configured</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="2" checked>Turbine Bypass Used</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="3" checked>Polisher Bypass Used</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="4" checked>MCC Water Levels < -3m </label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="5" checked>Turbine Aux Pump Used</label>
-                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="6" checked>Feedwater Pump Temperature Low</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="1">Deaerator Not Configured</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="2">Turbine Bypass Used</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="3">Polisher Bypass Used</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="4">MCC Water Levels < -3m </label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="5">Turbine Aux Pump Used</label>
+                            <label><input type="checkbox" class="subsystem-toggle" data-system="u2_abnormal_config" data-subsystem="6">Feedwater Pump Temperature Low</label>
                         </div>
                         <div class="system-rate">Rate Decrease: <span id="abnormal-rate">0.00</span> pts/s</div>
                     </div>


### PR DESCRIPTION
i did a bit more research with how point deductions work in u2, and i updated it to reflect 1.7.5's point gain properly

changes

[c65c6f4](https://github.com/nxrvi/rbwrmultitoolweb/pull/12/commits/c65c6f4190be425a5bf2c0b8792b4706c525b147):
- fixed edg auto deduction, it has a weight of 2 mcr autos when activated
- changed points decimal approximation from 2 -> 3 to better reflect point board in game
- added abnormal configs (turb bypass usage, polisher bypass usage, mcc levels < -3m, turb aux pump usage, fwp temps low). each of the abnorml configs costs the equivalent of 1 mcr auto
- moved da configured to abnormal config

[c373b3b](https://github.com/nxrvi/rbwrmultitoolweb/pull/12/commits/c373b3ba8f8577ed5a73093e24570d54dee393ff)
- unchecked the abnormal configs by default